### PR TITLE
Migrate storage layer from Excel files to Supabase Postgres

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,16 @@
         "@capacitor/core": "^7.4.2",
         "@mdi/font": "^7.4.47",
         "@nuxtjs/tailwindcss": "^6.14.0",
+        "@supabase/supabase-js": "^2.109.0",
         "axios": "^1.11.0",
         "exceljs": "^4.4.0",
         "nuxt": "^4.0.3",
+        "pg": "^8.22.0",
         "vue": "^3.5.18",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
+        "@types/pg": "^8.20.0",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "sass": "^1.90.0",
@@ -3863,6 +3866,90 @@
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "license": "CC0-1.0"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.109.0.tgz",
+      "integrity": "sha512-krf61vksi92kEUYtNH70GnIMOoQqLBAKG2e3Aha4e/0uJA6i1OWCxL7WUGHo6c0Vu/w96Y1DdnkYz0NOg0kYog==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.109.0.tgz",
+      "integrity": "sha512-IiwAspZrVrBRYQoFgSJvkcA9iJvTCw8nHOdvlKARDushlw/x1YY3YJYtwwgZFtl7utUbTiZ5SwohXPNgnpZM+g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.109.0.tgz",
+      "integrity": "sha512-Xk4gzuzyrGIPWCUuJolDQS/9zdFZDEXRhNsVeOHEKwFr+vpNU0himsHtLOhSEYlyPqwmeY8LUCKL6bLsDp0ScA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.109.0.tgz",
+      "integrity": "sha512-q9tjGUgWLNhfLz6HeYE7yl6FG9WEsnr6bFmmLpn2Nakxp3Z36pqI4xu0xns5/n8Xtq10HVcy9CRxOxgvviCM4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.109.0.tgz",
+      "integrity": "sha512-j119SdEuwrOPGqiPjshpfovrQPFqeATKg990jNV88Ie+SEufznzVD2mL5kQvly+z2oVBeZn+pweU0QN/OYLmJw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.109.0.tgz",
+      "integrity": "sha512-eNpUGegTT3hhoTK9j6aLViVjybYtdq6Ishb4BkVLi5tT58S1D80n7dmALMoBWkbrYG4uQv30c8iAB6nZylX0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.109.0",
+        "@supabase/functions-js": "2.109.0",
+        "@supabase/postgrest-js": "2.109.0",
+        "@supabase/realtime-js": "2.109.0",
+        "@supabase/storage-js": "2.109.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3902,6 +3989,18 @@
       "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
       "license": "MIT"
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -7240,6 +7339,15 @@
         "node": ">=16.17.0"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9443,6 +9551,95 @@
       "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10140,6 +10337,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -12882,6 +13118,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,16 @@
     "@capacitor/core": "^7.4.2",
     "@mdi/font": "^7.4.47",
     "@nuxtjs/tailwindcss": "^6.14.0",
+    "@supabase/supabase-js": "^2.109.0",
     "axios": "^1.11.0",
     "exceljs": "^4.4.0",
     "nuxt": "^4.0.3",
+    "pg": "^8.22.0",
     "vue": "^3.5.18",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "@types/pg": "^8.20.0",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "sass": "^1.90.0",

--- a/pages/expense.vue
+++ b/pages/expense.vue
@@ -259,7 +259,6 @@ const onSubmitExpense = async () => {
         body: {
           userid,
           expenseid: editingEntry.value.expenseid,
-          originalCategory: editingEntry.value.category,
           category,
           amount: value,
           dateofexpense: expenseDate.value,
@@ -285,7 +284,7 @@ const onDeleteExpense = async (entry: ExpenseEntry) => {
   try {
     await $fetch('/expenses', {
       method: 'DELETE',
-      query: { userid, expenseid: entry.expenseid, category: entry.category },
+      query: { userid, expenseid: entry.expenseid },
     })
     await loadExpenses()
   } catch (err: any) {

--- a/server/routes/expenses/index.delete.ts
+++ b/server/routes/expenses/index.delete.ts
@@ -4,14 +4,13 @@ export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const userid = String(query.userid ?? '')
   const expenseid = String(query.expenseid ?? '')
-  const category = String(query.category ?? '')
 
-  if (!userid || !expenseid || !category) {
-    throw createError({ statusCode: 400, statusMessage: 'userid, expenseid and category are required' })
+  if (!userid || !expenseid) {
+    throw createError({ statusCode: 400, statusMessage: 'userid and expenseid are required' })
   }
 
   try {
-    await deleteExpense(userid, expenseid, category)
+    await deleteExpense(userid, expenseid)
     return { success: true }
   } catch (err: any) {
     if (err.message === 'EXPENSE_NOT_FOUND') {

--- a/server/routes/expenses/index.get.ts
+++ b/server/routes/expenses/index.get.ts
@@ -1,4 +1,4 @@
-import { aggregateExpensesByCategory, flattenExpenseEntries, getCategories, getExpenses } from '../../utils/spendnest'
+import { aggregateExpensesByCategory, getCategories, getExpenses } from '../../utils/spendnest'
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event)
@@ -10,24 +10,17 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'userid is required' })
   }
 
-  const [categories, allExpenses] = await Promise.all([getCategories(userid), getExpenses(userid)])
+  const [categories, entries] = await Promise.all([
+    getCategories(userid),
+    getExpenses(userid, from || undefined, to || undefined),
+  ])
 
-  // dateofexpense is stored as YYYY-MM-DD, so plain string comparison sorts chronologically.
-  const expenses = allExpenses.filter(row => {
-    if (from && row.dateofexpense < from) return false
-    if (to && row.dateofexpense > to) return false
-    return true
-  })
-
-  const totalsByCategory = aggregateExpensesByCategory(expenses)
-
+  const totalsByCategory = aggregateExpensesByCategory(entries)
   const totals = categories.map(c => ({
     catid: c.catid,
     category: c.category,
     amount: totalsByCategory[c.category] || 0,
   }))
-
-  const entries = flattenExpenseEntries(expenses)
 
   return { entries, totals }
 })

--- a/server/routes/expenses/index.put.ts
+++ b/server/routes/expenses/index.put.ts
@@ -6,13 +6,12 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const userid = String(body?.userid ?? '').trim()
   const expenseid = String(body?.expenseid ?? '').trim()
-  const originalCategory = String(body?.originalCategory ?? '').trim()
   const category = String(body?.category ?? '').trim()
   const amount = Number(body?.amount)
   const dateofexpense = String(body?.dateofexpense ?? '').trim()
 
-  if (!userid || !expenseid || !originalCategory || !category) {
-    throw createError({ statusCode: 400, statusMessage: 'userid, expenseid, originalCategory and category are required' })
+  if (!userid || !expenseid || !category) {
+    throw createError({ statusCode: 400, statusMessage: 'userid, expenseid and category are required' })
   }
   if (!Number.isFinite(amount) || amount <= 0) {
     throw createError({ statusCode: 400, statusMessage: 'amount must be a positive number' })
@@ -22,7 +21,7 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    return await updateExpense(userid, expenseid, originalCategory, category, amount, dateofexpense)
+    return await updateExpense(userid, expenseid, category, amount, dateofexpense)
   } catch (err: any) {
     if (err.message === 'EXPENSE_NOT_FOUND') {
       throw createError({ statusCode: 404, statusMessage: 'Expense not found' })

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -1,0 +1,17 @@
+import { Pool } from 'pg'
+
+let pool: Pool | null = null
+
+export function getPool(): Pool {
+  if (!pool) {
+    const connectionString = process.env.DATABASE_URL
+    if (!connectionString) {
+      throw new Error('DATABASE_URL is not set')
+    }
+    pool = new Pool({
+      connectionString,
+      ssl: { rejectUnauthorized: false },
+    })
+  }
+  return pool
+}

--- a/server/utils/spendnest.ts
+++ b/server/utils/spendnest.ts
@@ -1,17 +1,5 @@
-import { randomBytes, randomUUID, scryptSync, timingSafeEqual } from 'node:crypto'
-import { readRows, withFileLock, writeRows } from './excelStore'
-
-export const USERS_FILE = 'users.xlsx'
-export const USERS_SHEET = 'Users'
-export const USER_HEADERS = ['userid', 'name', 'phone', 'email', 'password']
-
-export const CATEGORIES_FILE = 'categories.xlsx'
-export const CATEGORIES_SHEET = 'Categories'
-export const CATEGORY_HEADERS = ['catid', 'category', 'createdon', 'userid']
-
-export const EXPENSES_FILE = 'expenses.xlsx'
-export const EXPENSES_SHEET = 'Expenses'
-export const EXPENSE_HEADERS = ['expenseid', 'expensedata', 'userid', 'dateofexpense']
+import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto'
+import { getPool } from './db'
 
 export interface UserRow {
   userid: string
@@ -28,10 +16,10 @@ export interface CategoryRow {
   userid: string
 }
 
-export interface ExpenseRow {
+export interface ExpenseEntry {
   expenseid: string
-  expensedata: string
-  userid: string
+  category: string
+  amount: number
   dateofexpense: string
 }
 
@@ -50,166 +38,113 @@ export function verifyPassword(plain: string, stored: string) {
   return timingSafeEqual(candidate, expected)
 }
 
-export async function getUsers(): Promise<UserRow[]> {
-  return readRows(USERS_FILE, USERS_SHEET, USER_HEADERS) as Promise<UserRow[]>
-}
-
 export async function findUserByEmail(email: string): Promise<UserRow | undefined> {
-  const users = await getUsers()
-  return users.find(u => String(u.email).toLowerCase() === email.toLowerCase())
+  const { rows } = await getPool().query(
+    'select userid, name, phone, email, password from users where lower(email) = lower($1)',
+    [email],
+  )
+  return rows[0]
 }
 
 export async function createUser(data: { name: string; phone: string; email: string; password: string }): Promise<UserRow> {
-  return withFileLock(USERS_FILE, async () => {
-    const users = await getUsers()
-    if (users.some(u => String(u.email).toLowerCase() === data.email.toLowerCase())) {
-      throw new Error('EMAIL_EXISTS')
-    }
-    const user: UserRow = {
-      userid: randomUUID(),
-      name: data.name,
-      phone: data.phone,
-      email: data.email,
-      password: hashPassword(data.password),
-    }
-    users.push(user)
-    await writeRows(USERS_FILE, USERS_SHEET, USER_HEADERS, users)
-    return user
-  })
+  if (await findUserByEmail(data.email)) {
+    throw new Error('EMAIL_EXISTS')
+  }
+  const { rows } = await getPool().query(
+    `insert into users (name, phone, email, password)
+     values ($1, $2, $3, $4)
+     returning userid, name, phone, email, password`,
+    [data.name, data.phone, data.email, hashPassword(data.password)],
+  )
+  return rows[0]
 }
 
 export async function getCategories(userid: string): Promise<CategoryRow[]> {
-  const rows = (await readRows(CATEGORIES_FILE, CATEGORIES_SHEET, CATEGORY_HEADERS)) as CategoryRow[]
-  return rows.filter(r => r.userid === userid)
+  const { rows } = await getPool().query(
+    `select catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid
+     from categories where userid = $1 order by createdon desc`,
+    [userid],
+  )
+  return rows
 }
 
 export async function createCategory(userid: string, category: string): Promise<CategoryRow> {
-  return withFileLock(CATEGORIES_FILE, async () => {
-    const rows = (await readRows(CATEGORIES_FILE, CATEGORIES_SHEET, CATEGORY_HEADERS)) as CategoryRow[]
-    const exists = rows.some(r => r.userid === userid && String(r.category).toLowerCase() === category.toLowerCase())
-    if (exists) {
+  try {
+    const { rows } = await getPool().query(
+      `insert into categories (category, userid)
+       values ($1, $2)
+       returning catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid`,
+      [category, userid],
+    )
+    return rows[0]
+  } catch (err: any) {
+    if (err.code === '23505') {
       throw new Error('CATEGORY_EXISTS')
     }
-    const row: CategoryRow = {
-      catid: randomUUID(),
-      category,
-      createdon: new Date().toISOString(),
-      userid,
-    }
-    rows.push(row)
-    await writeRows(CATEGORIES_FILE, CATEGORIES_SHEET, CATEGORY_HEADERS, rows)
-    return row
-  })
+    throw err
+  }
 }
 
-export async function getExpenses(userid: string): Promise<ExpenseRow[]> {
-  const rows = (await readRows(EXPENSES_FILE, EXPENSES_SHEET, EXPENSE_HEADERS)) as ExpenseRow[]
-  return rows.filter(r => r.userid === userid)
+export async function getExpenses(userid: string, from?: string, to?: string): Promise<ExpenseEntry[]> {
+  const conditions = ['userid = $1']
+  const params: any[] = [userid]
+  if (from) {
+    params.push(from)
+    conditions.push(`dateofexpense >= $${params.length}`)
+  }
+  if (to) {
+    params.push(to)
+    conditions.push(`dateofexpense <= $${params.length}`)
+  }
+
+  const { rows } = await getPool().query(
+    `select expenseid, category, amount, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense
+     from expenses where ${conditions.join(' and ')} order by dateofexpense desc`,
+    params,
+  )
+  return rows.map(r => ({ ...r, amount: Number(r.amount) }))
 }
 
-export async function addExpense(userid: string, category: string, amount: number, dateofexpense: string): Promise<ExpenseRow> {
-  return withFileLock(EXPENSES_FILE, async () => {
-    const rows = (await readRows(EXPENSES_FILE, EXPENSES_SHEET, EXPENSE_HEADERS)) as ExpenseRow[]
-    const row: ExpenseRow = {
-      expenseid: randomUUID(),
-      expensedata: JSON.stringify({ [category]: amount }),
-      userid,
-      dateofexpense,
-    }
-    rows.push(row)
-    await writeRows(EXPENSES_FILE, EXPENSES_SHEET, EXPENSE_HEADERS, rows)
-    return row
-  })
+export async function addExpense(userid: string, category: string, amount: number, dateofexpense: string): Promise<ExpenseEntry> {
+  const { rows } = await getPool().query(
+    `insert into expenses (category, amount, userid, dateofexpense)
+     values ($1, $2, $3, $4)
+     returning expenseid, category, amount, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
+    [category, amount, userid, dateofexpense],
+  )
+  return { ...rows[0], amount: Number(rows[0].amount) }
 }
 
-// A single expenseid row can hold more than one category key (e.g. legacy
-// rows written before each submit became its own row). The "View All" list
-// flattens each key into its own line item, so edit/delete must only touch
-// the one category key being acted on — never overwrite the whole row.
 export async function updateExpense(
   userid: string,
   expenseid: string,
-  originalCategory: string,
   category: string,
   amount: number,
   dateofexpense: string,
-): Promise<ExpenseRow> {
-  return withFileLock(EXPENSES_FILE, async () => {
-    const rows = (await readRows(EXPENSES_FILE, EXPENSES_SHEET, EXPENSE_HEADERS)) as ExpenseRow[]
-    const row = rows.find(r => r.expenseid === expenseid && r.userid === userid)
-    if (!row) {
-      throw new Error('EXPENSE_NOT_FOUND')
-    }
-    const data = JSON.parse(row.expensedata || '{}')
-    delete data[originalCategory]
-    data[category] = amount
-    row.dateofexpense = dateofexpense
-    row.expensedata = JSON.stringify(data)
-    await writeRows(EXPENSES_FILE, EXPENSES_SHEET, EXPENSE_HEADERS, rows)
-    return row
-  })
+): Promise<ExpenseEntry> {
+  const { rows } = await getPool().query(
+    `update expenses set category = $1, amount = $2, dateofexpense = $3
+     where expenseid = $4 and userid = $5
+     returning expenseid, category, amount, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
+    [category, amount, dateofexpense, expenseid, userid],
+  )
+  if (!rows[0]) {
+    throw new Error('EXPENSE_NOT_FOUND')
+  }
+  return { ...rows[0], amount: Number(rows[0].amount) }
 }
 
-export async function deleteExpense(userid: string, expenseid: string, category: string): Promise<void> {
-  return withFileLock(EXPENSES_FILE, async () => {
-    const rows = (await readRows(EXPENSES_FILE, EXPENSES_SHEET, EXPENSE_HEADERS)) as ExpenseRow[]
-    const row = rows.find(r => r.expenseid === expenseid && r.userid === userid)
-    if (!row) {
-      throw new Error('EXPENSE_NOT_FOUND')
-    }
-    const data = JSON.parse(row.expensedata || '{}')
-    delete data[category]
-
-    if (Object.keys(data).length === 0) {
-      rows.splice(rows.indexOf(row), 1)
-    } else {
-      row.expensedata = JSON.stringify(data)
-    }
-
-    await writeRows(EXPENSES_FILE, EXPENSES_SHEET, EXPENSE_HEADERS, rows)
-  })
+export async function deleteExpense(userid: string, expenseid: string): Promise<void> {
+  const { rowCount } = await getPool().query('delete from expenses where expenseid = $1 and userid = $2', [expenseid, userid])
+  if (rowCount === 0) {
+    throw new Error('EXPENSE_NOT_FOUND')
+  }
 }
 
-export function aggregateExpensesByCategory(rows: ExpenseRow[]): Record<string, number> {
+export function aggregateExpensesByCategory(rows: ExpenseEntry[]): Record<string, number> {
   const totals: Record<string, number> = {}
   for (const row of rows) {
-    let data: Record<string, number> = {}
-    try {
-      data = JSON.parse(row.expensedata || '{}')
-    } catch {
-      continue
-    }
-    for (const [category, amount] of Object.entries(data)) {
-      totals[category] = (totals[category] || 0) + (Number(amount) || 0)
-    }
+    totals[row.category] = (totals[row.category] || 0) + row.amount
   }
   return totals
-}
-
-export interface ExpenseEntry {
-  expenseid: string
-  category: string
-  amount: number
-  dateofexpense: string
-}
-
-export function flattenExpenseEntries(rows: ExpenseRow[]): ExpenseEntry[] {
-  const entries: ExpenseEntry[] = []
-  for (const row of rows) {
-    let data: Record<string, number> = {}
-    try {
-      data = JSON.parse(row.expensedata || '{}')
-    } catch {
-      continue
-    }
-    for (const [category, amount] of Object.entries(data)) {
-      entries.push({
-        expenseid: row.expenseid,
-        category,
-        amount: Number(amount) || 0,
-        dateofexpense: row.dateofexpense,
-      })
-    }
-  }
-  return entries.sort((a, b) => b.dateofexpense.localeCompare(a.dateofexpense))
 }


### PR DESCRIPTION
Netlify's serverless functions have no persistent local filesystem, so the .xlsx-file-based storage couldn't survive between requests once deployed. Replaces it with a Postgres-backed layer (via Supabase), normalizing the expenses table to real category/amount columns instead of a JSON blob per row, which also removes the class of bugs where editing one category could wipe out a sibling category sharing the same row. exceljs and the old Excel storage code are left in place for possible future use, just no longer wired into the app.