### PR TITLE
Add landing page, sign-out, forgot password, and app-wide theme

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,6 +4,7 @@
       <v-tab value="expense" @click="router.push('/expense')">Expense</v-tab>
       <v-tab value="category" @click="router.push('/category')">Category</v-tab>
     </v-tabs>
+    <v-btn icon="mdi-logout" variant="text" @click="onSignOut" title="Sign out" />
   </v-app-bar>
 
   <v-main>
@@ -34,4 +35,11 @@ watch(() => route.path, () => {
   showNav.value = !!localStorage.getItem('spendnest_userid')
   syncTabFromRoute()
 })
+
+const onSignOut = () => {
+  localStorage.removeItem('spendnest_userid')
+  localStorage.removeItem('spendnest_username')
+  showNav.value = false
+  router.push('/')
+}
 </script>

--- a/pages/forgot-password.vue
+++ b/pages/forgot-password.vue
@@ -8,23 +8,74 @@
             Reset Your Password
           </v-card-title>
 
-          <!-- Email -->
-          <v-text-field
-            v-model="email"
-            label="Email Address"
-            type="email"
-            variant="outlined"
-            class="mb-4"
-            clearable
-          />
+          <v-alert v-if="errorMessage" type="error" density="compact" class="mb-4" variant="tonal">
+            {{ errorMessage }}
+          </v-alert>
 
-          <!-- Reset Button -->
-          <v-btn block color="primary" class="mb-4" @click="onReset">
-            Send Reset Link
-          </v-btn>
+          <!-- Step 1: email -->
+          <template v-if="step === 'email'">
+            <v-text-field
+              v-model="email"
+              label="Email Address"
+              type="email"
+              variant="outlined"
+              class="mb-4"
+              clearable
+              @keyup.enter="onContinue"
+            />
+            <v-btn block color="primary" class="mb-4" @click="onContinue">
+              Continue
+            </v-btn>
+          </template>
+
+          <!-- Step 2: new password -->
+          <template v-else-if="step === 'reset'">
+            <p class="text-caption text-grey mb-4">Resetting password for <b>{{ email }}</b></p>
+
+            <v-text-field
+              v-model="password"
+              label="New Password"
+              :type="showPassword ? 'text' : 'password'"
+              :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+              @click:append-inner="showPassword = !showPassword"
+              variant="outlined"
+              class="mb-4"
+              clearable
+              hint="At least 7 characters"
+            />
+
+            <v-text-field
+              v-model="confirmPassword"
+              label="Confirm New Password"
+              :type="showConfirmPassword ? 'text' : 'password'"
+              :append-inner-icon="showConfirmPassword ? 'mdi-eye-off' : 'mdi-eye'"
+              @click:append-inner="showConfirmPassword = !showConfirmPassword"
+              variant="outlined"
+              class="mb-4"
+              clearable
+              @keyup.enter="onReset"
+            />
+
+            <v-btn block color="primary" class="mb-2" @click="onReset">
+              Reset Password
+            </v-btn>
+            <v-btn block variant="text" @click="step = 'email'">
+              Back
+            </v-btn>
+          </template>
+
+          <!-- Step 3: done -->
+          <template v-else>
+            <v-alert type="success" density="compact" class="mb-4" variant="tonal">
+              Password updated. You can log in now.
+            </v-alert>
+            <v-btn block color="primary" class="mb-4" to="/login">
+              Go to Login
+            </v-btn>
+          </template>
 
           <!-- Back to login -->
-          <div class="text-center">
+          <div v-if="step !== 'done'" class="text-center">
             <NuxtLink to="/login" class="text-blue font-weight-medium">
               Back to Login
             </NuxtLink>
@@ -40,9 +91,45 @@ import { ref } from 'vue'
 
 definePageMeta({ layout: 'auth' })
 
-const email = ref('')
+const MIN_PASSWORD_LENGTH = 7
 
-const onReset = () => {
-  console.log('Reset link sent to:', email.value)
+const step = ref<'email' | 'reset' | 'done'>('email')
+const email = ref('')
+const password = ref('')
+const confirmPassword = ref('')
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
+const errorMessage = ref('')
+
+const onContinue = () => {
+  errorMessage.value = ''
+  if (!email.value) {
+    errorMessage.value = 'Please enter your email.'
+    return
+  }
+  step.value = 'reset'
+}
+
+const onReset = async () => {
+  errorMessage.value = ''
+
+  if (password.value.length < MIN_PASSWORD_LENGTH) {
+    errorMessage.value = `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`
+    return
+  }
+  if (password.value !== confirmPassword.value) {
+    errorMessage.value = 'Passwords do not match.'
+    return
+  }
+
+  try {
+    await $fetch('/auth/reset-password', {
+      method: 'POST',
+      body: { email: email.value, password: password.value, confirmPassword: confirmPassword.value },
+    })
+    step.value = 'done'
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || 'Failed to reset password'
+  }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,18 +1,34 @@
 <template>
-  <v-container class="fill-height d-flex justify-center align-center" fluid>
-    <v-row class="w-100" justify="center">
-      <v-col cols="12" sm="8" md="4">
-        <v-card class="pa-6 pa-md-8 rounded-xl text-center" elevation="10">
-          <v-card-title class="text-h5 mb-2">
-            SpendNest
-          </v-card-title>
-          <v-card-subtitle>
-            Use the Expense and Category tabs above to get started.
-          </v-card-subtitle>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+  <div class="landing">
+    <header class="topbar">
+      <div class="brand">
+        <span class="brand-mark" v-html="logoSvg" />
+        <span class="brand-word">spend<b>Nest</b></span>
+      </div>
+      <div class="topbar-actions">
+        <NuxtLink to="/login" class="btn btn-ghost">Login</NuxtLink>
+        <NuxtLink to="/signup" class="btn btn-solid">Sign Up</NuxtLink>
+      </div>
+    </header>
+
+    <main class="hero">
+      <div class="hero-mark" v-html="logoSvg" />
+      <h1 class="wordmark">spend<b>Nest</b></h1>
+      <p class="tagline">Spend wisely, save gently, live fully.</p>
+
+      <ul class="features">
+        <li v-for="f in features" :key="f.title">
+          <span class="feature-icon"><v-icon :icon="f.icon" size="22" /></span>
+          <span class="feature-copy">
+            <span class="feature-title">{{ f.title }}</span>
+            <span class="feature-desc">{{ f.desc }}</span>
+          </span>
+        </li>
+      </ul>
+    </main>
+
+    <div class="decor-leaf" aria-hidden="true"></div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -23,8 +39,216 @@ const router = useRouter()
 
 onMounted(() => {
   const userid = localStorage.getItem('spendnest_userid')
-  if (!userid) {
-    router.push('/login')
+  if (userid) {
+    router.push('/expense')
   }
 })
+
+const features = [
+  { icon: 'mdi-chart-line', title: 'Track Expenses', desc: 'Know where your money goes' },
+  { icon: 'mdi-target', title: 'Set Goals', desc: 'Plan today for a better tomorrow' },
+  { icon: 'mdi-piggy-bank-outline', title: 'Save More', desc: 'Build healthy habits and grow your savings' },
+  { icon: 'mdi-bell-ring-outline', title: 'Smart Alerts', desc: 'Get notified. Stay in control.' },
+]
+
+const logoSvg = `
+<svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 62 C 14 46, 86 46, 86 62 C 68 54, 32 54, 14 62 Z" fill="#2F6B3D"/>
+  <path d="M20 66 C 20 54, 80 54, 80 66 C 64 60, 36 60, 20 66 Z" fill="#3E8149"/>
+  <path d="M50 20 C 40 20, 33 28, 33 38 C 33 47, 40 54, 49 55 L 45 60 L 54 58 C 63 56, 69 48, 69 38 C 69 27, 61 20, 50 20 Z" fill="#2F6B3D"/>
+  <circle cx="58" cy="33" r="2.6" fill="#F5F1E8"/>
+  <path d="M69 36 L 78 33 L 70 41 Z" fill="#2F6B3D"/>
+  <path d="M35 30 C 28 24, 20 26, 16 33 C 24 33, 30 33, 35 30 Z" fill="#4C9457"/>
+</svg>
+`
 </script>
+
+<style scoped>
+.landing {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #f5f1e8;
+  color: #1f2420;
+  position: relative;
+  overflow: hidden;
+  font-family: 'Segoe UI', Roboto, system-ui, sans-serif;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  z-index: 2;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1f2420;
+}
+
+.brand-mark {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+}
+
+.brand-mark :deep(svg) {
+  width: 100%;
+  height: 100%;
+}
+
+.brand-word b {
+  color: #2f6b3d;
+  font-weight: 700;
+}
+
+.topbar-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.btn {
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+.btn:focus-visible {
+  outline: 2px solid #2f6b3d;
+  outline-offset: 2px;
+}
+
+.btn-ghost {
+  color: #2f6b3d;
+  border: 1.5px solid #2f6b3d;
+  background: transparent;
+}
+
+.btn-solid {
+  color: #f5f1e8;
+  background: #2f6b3d;
+}
+
+.hero {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 24px 28px 120px;
+  z-index: 2;
+}
+
+.hero-mark {
+  width: 96px;
+  height: 96px;
+  margin-top: 12px;
+  margin-bottom: 8px;
+}
+
+.hero-mark :deep(svg) {
+  width: 100%;
+  height: 100%;
+}
+
+.wordmark {
+  font-size: 2.1rem;
+  font-weight: 700;
+  margin: 4px 0 6px;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+}
+
+.wordmark b {
+  color: #2f6b3d;
+  font-weight: 700;
+}
+
+.tagline {
+  font-size: 1rem;
+  color: #4b5148;
+  margin: 0 0 36px;
+  max-width: 26ch;
+}
+
+.features {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  width: 100%;
+  max-width: 360px;
+  text-align: left;
+}
+
+.features li {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.feature-icon {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #2f6b3d;
+  color: #f5f1e8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feature-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 2px;
+}
+
+.feature-title {
+  font-weight: 700;
+  font-size: 0.98rem;
+  color: #1f2420;
+}
+
+.feature-desc {
+  font-size: 0.85rem;
+  color: #6b7268;
+}
+
+.decor-leaf {
+  position: absolute;
+  left: -40px;
+  bottom: -40px;
+  width: 220px;
+  height: 220px;
+  background:
+    radial-gradient(ellipse at 30% 30%, rgba(76, 148, 87, 0.28), transparent 60%),
+    radial-gradient(ellipse at 60% 70%, rgba(47, 107, 61, 0.22), transparent 55%);
+  filter: blur(2px);
+  pointer-events: none;
+  z-index: 1;
+}
+
+@media (min-width: 640px) {
+  .hero {
+    padding-bottom: 80px;
+  }
+}
+</style>

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -43,7 +43,9 @@
       <v-text-field
         v-model="password"
         label="Password"
-        type="password"
+        :type="showPassword ? 'text' : 'password'"
+        :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+        @click:append-inner="showPassword = !showPassword"
         variant="outlined"
         class="mb-1"
         clearable
@@ -65,7 +67,9 @@
       <v-text-field
         v-model="confirmPassword"
         label="Confirm Password"
-        type="password"
+        :type="showConfirmPassword ? 'text' : 'password'"
+        :append-inner-icon="showConfirmPassword ? 'mdi-eye-off' : 'mdi-eye'"
+        @click:append-inner="showConfirmPassword = !showConfirmPassword"
         variant="outlined"
         class="mb-4"
         clearable
@@ -118,6 +122,8 @@ const email = ref('')
 const phone = ref('')
 const password = ref('')
 const confirmPassword = ref('')
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
 const errorMessage = ref('')
 const router = useRouter()
 
@@ -170,7 +176,7 @@ const onSignup = async () => {
     })
 
     alert('Account created! Please log in.')
-    router.push('/login')
+    router.push('/login') 
   } catch (err: any) {
     errorMessage.value = err?.data?.statusMessage || 'Signup failed'
   }

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -20,6 +20,25 @@ export default defineNuxtPlugin(nuxtApp => {
         mdi,
       },
     },
+    theme: {
+      defaultTheme: 'spendnest',
+      themes: {
+        spendnest: {
+          dark: false,
+          colors: {
+            primary: '#2F6B3D',
+            'primary-darken-1': '#245530',
+            secondary: '#4C9457',
+            background: '#F5F1E8',
+            surface: '#FFFFFF',
+            error: '#B00020',
+            info: '#2196F3',
+            success: '#2F6B3D',
+            warning: '#FB8C00',
+          },
+        },
+      },
+    },
   })
 
   nuxtApp.vueApp.use(vuetify)

--- a/server/routes/auth/reset-password.post.ts
+++ b/server/routes/auth/reset-password.post.ts
@@ -1,0 +1,28 @@
+import { resetPassword } from '../../utils/spendnest'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const email = String(body?.email ?? '').trim()
+  const password = String(body?.password ?? '')
+  const confirmPassword = String(body?.confirmPassword ?? '')
+
+  if (!email || !password) {
+    throw createError({ statusCode: 400, statusMessage: 'Email and new password are required' })
+  }
+  if (password.length < 7) {
+    throw createError({ statusCode: 400, statusMessage: 'Password must be at least 7 characters' })
+  }
+  if (password !== confirmPassword) {
+    throw createError({ statusCode: 400, statusMessage: 'Passwords do not match' })
+  }
+
+  try {
+    await resetPassword(email, password)
+    return { success: true }
+  } catch (err: any) {
+    if (err.message === 'USER_NOT_FOUND') {
+      throw createError({ statusCode: 404, statusMessage: 'No account found with that email' })
+    }
+    throw err
+  }
+})

--- a/server/utils/spendnest.ts
+++ b/server/utils/spendnest.ts
@@ -59,6 +59,16 @@ export async function createUser(data: { name: string; phone: string; email: str
   return rows[0]
 }
 
+export async function resetPassword(email: string, newPassword: string): Promise<void> {
+  const { rowCount } = await getPool().query(
+    'update users set password = $1 where lower(email) = lower($2)',
+    [hashPassword(newPassword), email],
+  )
+  if (rowCount === 0) {
+    throw new Error('USER_NOT_FOUND')
+  }
+}
+
 export async function getCategories(userid: string): Promise<CategoryRow[]> {
   const { rows } = await getPool().query(
     `select catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid
@@ -127,7 +137,7 @@ export async function updateExpense(
      where expenseid = $4 and userid = $5
      returning expenseid, category, amount, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
     [category, amount, dateofexpense, expenseid, userid],
-  )
+  ) 
   if (!rows[0]) {
     throw new Error('EXPENSE_NOT_FOUND')
   }


### PR DESCRIPTION
- New spendNest-branded landing page at / with Login/Sign Up CTAs, replacing the old auto-redirect-to-login stub.
- Sign-out button in the persistent nav layout, clears the session and returns to the landing page.
- Password visibility toggle (eye icon) on signup's password fields.
- Simple in-app forgot-password flow (email -> set new password directly, no email service wired up yet).
- App-wide Vuetify theme using the landing page's green/cream palette instead of Vuetify's default blue.