### PR TITLE
Add expense description, per-tab totals, and a view-by-date breakdown

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,29 @@
+Ship the current uncommitted changes: create a branch, commit, push, and open a pull request — end to end, without asking the user for input at any step. Use sensible defaults and just proceed; only stop early if there is a real blocker (e.g. nothing to commit, or uncommitted changes that look unrelated/risky to include).
+
+Steps to follow:
+
+1. Run `git status --porcelain=v1` and `git diff` (and `git diff --cached` if anything is already staged) to see exactly what changed. If there is nothing to commit, tell the user and stop — do not create an empty branch/commit.
+
+2. Check for anything that shouldn't be committed (`.env`, credentials, secrets, stray build output) before staging anything. Never stage those files; if the only changes are in files like this, stop and tell the user instead of committing them.
+
+3. Determine the base branch: this repo deploys from `main` (Netlify's production branch), so branch off `main` unless the working tree is already stacked on top of another in-progress feature branch — use judgement, but default to `main`.
+
+4. Derive a short, descriptive kebab-case branch name from the actual content of the changes (read the diff/file list yourself and summarize what changed — don't just concatenate filenames). Prefix it `feature/` to match this repo's convention, e.g. `feature/add-expense-date-filter`.
+
+5. Create the branch: `git checkout -b <branch-name>`.
+
+6. Stage the relevant changed files explicitly (never `git add -A` / `git add .` blindly).
+
+7. Commit with a concise message describing *why* the change was made (not just what), matching this repo's existing commit style (check `git log --oneline` for examples). Always end the commit message with:
+   ```
+   Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+   ```
+
+8. Push: `git push -u origin <branch-name>`.
+
+9. Open the PR:
+   - Check `gh auth status` first.
+   - If authenticated, run `gh pr create --base main --head <branch-name> --title "..." --body "..."` and report the returned URL.
+   - If `gh` is not authenticated, don't stop to sort out authentication or ask the user to log in mid-task — just hand back the manual PR-creation link instead: `https://github.com/Siva-palaniappan/Siva-Work-space/compare/main...<branch-name>`.
+
+10. Report back concisely: the branch name, a one-line summary of the commit, and either the PR URL or the manual-merge link — no other confirmation needed.

--- a/pages/expense.vue
+++ b/pages/expense.vue
@@ -11,13 +11,14 @@
             <v-tab value="add">Add Expense</v-tab>
             <v-tab value="all">View All</v-tab>
             <v-tab value="total">View Total</v-tab>
+            <v-tab value="byDate">View by Date</v-tab>
           </v-tabs>
 
           <v-alert v-if="errorMessage" type="error" density="compact" class="mb-4" variant="tonal">
             {{ errorMessage }}
           </v-alert>
 
-          <div v-if="tab === 'all' || tab === 'total'" class="d-flex align-center mb-4" style="gap: 8px;">
+          <div v-if="tab === 'all' || tab === 'total' || tab === 'byDate'" class="d-flex align-center mb-4" style="gap: 8px;">
             <v-text-field
               v-model="dateFrom"
               label="From"
@@ -69,7 +70,7 @@
                   v-for="item in entries"
                   :key="item.expenseid"
                   :title="`${item.category} — ${item.amount.toFixed(2)}`"
-                  :subtitle="formatDate(item.dateofexpense)"
+                  :subtitle="item.description ? `${formatDate(item.dateofexpense)} — ${item.description}` : formatDate(item.dateofexpense)"
                 >
                   <template #append>
                     <v-btn icon="mdi-pencil" variant="text" size="small" @click="openEditDialog(item)" />
@@ -78,6 +79,14 @@
                 </v-list-item>
               </v-list>
               <p v-else class="text-center text-grey mt-6">No expenses recorded yet.</p>
+
+              <template v-if="entries.length">
+                <v-divider class="mt-2" />
+                <div class="d-flex justify-space-between align-center px-2 py-3">
+                  <span class="font-weight-bold">Total</span>
+                  <span class="font-weight-bold">{{ entriesTotal.toFixed(2) }}</span>
+                </div>
+              </template>
             </v-window-item>
 
             <!-- View Total -->
@@ -94,6 +103,44 @@
                 </v-list-item>
               </v-list>
               <p v-else class="text-center text-grey mt-6">No categories yet.</p>
+
+              <template v-if="totals.length">
+                <v-divider class="mt-2" />
+                <div class="d-flex justify-space-between align-center px-2 py-3">
+                  <span class="font-weight-bold">Total</span>
+                  <span class="font-weight-bold">{{ categoriesTotal.toFixed(2) }}</span>
+                </div>
+              </template>
+            </v-window-item>
+
+            <!-- View by Date -->
+            <v-window-item value="byDate">
+              <div v-if="entriesByDate.length">
+                <div v-for="group in entriesByDate" :key="group.date" class="mb-4">
+                  <div class="text-subtitle-2 font-weight-bold px-2 mb-1">
+                    {{ formatDate(group.date) }}
+                  </div>
+                  <v-list lines="two" density="compact">
+                    <v-list-item
+                      v-for="item in group.entries"
+                      :key="item.expenseid"
+                      :title="`${item.category} — ${item.amount.toFixed(2)}`"
+                      :subtitle="item.description || undefined"
+                    >
+                      <template #append>
+                        <v-btn icon="mdi-pencil" variant="text" size="small" @click="openEditDialog(item)" />
+                        <v-btn icon="mdi-delete" variant="text" size="small" color="error" @click="onDeleteExpense(item)" />
+                      </template>
+                    </v-list-item>
+                  </v-list>
+                  <v-divider class="mt-1" />
+                  <div class="d-flex justify-space-between align-center px-2 py-2">
+                    <span class="font-weight-medium text-caption">Total for {{ formatDate(group.date) }}</span>
+                    <span class="font-weight-medium">{{ group.total.toFixed(2) }}</span>
+                  </div>
+                </div>
+              </div>
+              <p v-else class="text-center text-grey mt-6">No expenses recorded yet.</p>
             </v-window-item>
           </v-window>
         </v-card>
@@ -128,8 +175,17 @@
             label="Amount"
             type="number"
             variant="outlined"
+            class="mb-2"
             autofocus
             @keyup.enter="onSubmitExpense"
+          />
+
+          <v-textarea
+            v-model="description"
+            label="Description (optional)"
+            variant="outlined"
+            rows="2"
+            auto-grow
           />
         </v-card-text>
         <v-card-actions>
@@ -143,7 +199,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 interface Category {
@@ -157,6 +213,7 @@ interface ExpenseEntry {
   expenseid: string
   category: string
   amount: number
+  description: string
   dateofexpense: string
 }
 
@@ -164,6 +221,12 @@ interface ExpenseTotal {
   catid: string
   category: string
   amount: number
+}
+
+interface DateGroup {
+  date: string
+  entries: ExpenseEntry[]
+  total: number
 }
 
 const router = useRouter()
@@ -179,11 +242,28 @@ const editingEntry = ref<ExpenseEntry | null>(null)
 const selectedCategoryName = ref('')
 const amount = ref('')
 const expenseDate = ref('')
+const description = ref('')
 
 const dateFrom = ref('')
 const dateTo = ref('')
 
 let userid = ''
+
+const entriesTotal = computed(() => entries.value.reduce((sum, e) => sum + e.amount, 0))
+const categoriesTotal = computed(() => totals.value.reduce((sum, t) => sum + t.amount, 0))
+
+const entriesByDate = computed<DateGroup[]>(() => {
+  const groups = new Map<string, ExpenseEntry[]>()
+  for (const entry of entries.value) {
+    if (!groups.has(entry.dateofexpense)) groups.set(entry.dateofexpense, [])
+    groups.get(entry.dateofexpense)!.push(entry)
+  }
+  return Array.from(groups.entries()).map(([date, list]) => ({
+    date,
+    entries: list,
+    total: list.reduce((sum, e) => sum + e.amount, 0),
+  }))
+})
 
 const todayStr = () => new Date().toISOString().slice(0, 10)
 
@@ -224,6 +304,7 @@ const openAddDialog = (cat: Category) => {
   selectedCategoryName.value = cat.category
   amount.value = ''
   expenseDate.value = todayStr()
+  description.value = ''
   errorMessage.value = ''
   dialogOpen.value = true
 }
@@ -234,6 +315,7 @@ const openEditDialog = (entry: ExpenseEntry) => {
   selectedCategoryName.value = entry.category
   amount.value = String(entry.amount)
   expenseDate.value = entry.dateofexpense
+  description.value = entry.description
   errorMessage.value = ''
   dialogOpen.value = true
 }
@@ -262,12 +344,13 @@ const onSubmitExpense = async () => {
           category,
           amount: value,
           dateofexpense: expenseDate.value,
+          description: description.value,
         },
       })
     } else {
       await $fetch('/expenses', {
         method: 'POST',
-        body: { userid, category, amount: value, dateofexpense: expenseDate.value },
+        body: { userid, category, amount: value, dateofexpense: expenseDate.value, description: description.value },
       })
     }
     dialogOpen.value = false

--- a/server/routes/expenses/index.post.ts
+++ b/server/routes/expenses/index.post.ts
@@ -8,6 +8,7 @@ export default defineEventHandler(async (event) => {
   const category = String(body?.category ?? '').trim()
   const amount = Number(body?.amount)
   const dateofexpense = String(body?.dateofexpense ?? '').trim()
+  const description = String(body?.description ?? '').trim()
 
   if (!userid || !category) {
     throw createError({ statusCode: 400, statusMessage: 'userid and category are required' })
@@ -19,5 +20,5 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'dateofexpense must be a valid YYYY-MM-DD date' })
   }
 
-  return await addExpense(userid, category, amount, dateofexpense)
+  return await addExpense(userid, category, amount, dateofexpense, description)
 })

--- a/server/routes/expenses/index.put.ts
+++ b/server/routes/expenses/index.put.ts
@@ -9,6 +9,7 @@ export default defineEventHandler(async (event) => {
   const category = String(body?.category ?? '').trim()
   const amount = Number(body?.amount)
   const dateofexpense = String(body?.dateofexpense ?? '').trim()
+  const description = String(body?.description ?? '').trim()
 
   if (!userid || !expenseid || !category) {
     throw createError({ statusCode: 400, statusMessage: 'userid, expenseid and category are required' })
@@ -21,7 +22,7 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    return await updateExpense(userid, expenseid, category, amount, dateofexpense)
+    return await updateExpense(userid, expenseid, category, amount, dateofexpense, description)
   } catch (err: any) {
     if (err.message === 'EXPENSE_NOT_FOUND') {
       throw createError({ statusCode: 404, statusMessage: 'Expense not found' })

--- a/server/utils/spendnest.ts
+++ b/server/utils/spendnest.ts
@@ -20,6 +20,7 @@ export interface ExpenseEntry {
   expenseid: string
   category: string
   amount: number
+  description: string
   dateofexpense: string
 }
 
@@ -108,19 +109,25 @@ export async function getExpenses(userid: string, from?: string, to?: string): P
   }
 
   const { rows } = await getPool().query(
-    `select expenseid, category, amount, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense
+    `select expenseid, category, amount, coalesce(description, '') as description, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense
      from expenses where ${conditions.join(' and ')} order by dateofexpense desc`,
     params,
   )
   return rows.map(r => ({ ...r, amount: Number(r.amount) }))
 }
 
-export async function addExpense(userid: string, category: string, amount: number, dateofexpense: string): Promise<ExpenseEntry> {
+export async function addExpense(
+  userid: string,
+  category: string,
+  amount: number,
+  dateofexpense: string,
+  description: string,
+): Promise<ExpenseEntry> {
   const { rows } = await getPool().query(
-    `insert into expenses (category, amount, userid, dateofexpense)
-     values ($1, $2, $3, $4)
-     returning expenseid, category, amount, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
-    [category, amount, userid, dateofexpense],
+    `insert into expenses (category, amount, userid, dateofexpense, description)
+     values ($1, $2, $3, $4, $5)
+     returning expenseid, category, amount, coalesce(description, '') as description, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
+    [category, amount, userid, dateofexpense, description],
   )
   return { ...rows[0], amount: Number(rows[0].amount) }
 }
@@ -131,13 +138,14 @@ export async function updateExpense(
   category: string,
   amount: number,
   dateofexpense: string,
+  description: string,
 ): Promise<ExpenseEntry> {
   const { rows } = await getPool().query(
-    `update expenses set category = $1, amount = $2, dateofexpense = $3
-     where expenseid = $4 and userid = $5
-     returning expenseid, category, amount, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
-    [category, amount, dateofexpense, expenseid, userid],
-  ) 
+    `update expenses set category = $1, amount = $2, dateofexpense = $3, description = $4
+     where expenseid = $5 and userid = $6
+     returning expenseid, category, amount, coalesce(description, '') as description, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
+    [category, amount, dateofexpense, description, expenseid, userid],
+  )
   if (!rows[0]) {
     throw new Error('EXPENSE_NOT_FOUND')
   }


### PR DESCRIPTION
Adds an optional description field to expenses (schema, backend, and the add/edit dialog), a running total footer on View All/View Total, and a new View by Date tab that groups entries per day with a subtotal for each date. Also adds the /ship command for future branch+PR automation.