### PR TITLE
Add per-category monthly budget tracking

### DIFF
--- a/pages/category.vue
+++ b/pages/category.vue
@@ -8,12 +8,20 @@
           </v-card-title>
 
           <!-- Add category -->
-          <div class="d-flex mb-2">
+          <div class="d-flex mb-2" style="gap: 8px;">
             <v-text-field
               v-model="newCategory"
               label="New Category"
               variant="outlined"
-              class="mr-2"
+              density="comfortable"
+              clearable
+              @keyup.enter="onAddCategory"
+            />
+            <v-text-field
+              v-model="newBudget"
+              label="Monthly Budget (optional)"
+              type="number"
+              variant="outlined"
               density="comfortable"
               clearable
               @keyup.enter="onAddCategory"
@@ -33,13 +41,44 @@
               v-for="cat in categories"
               :key="cat.catid"
               :title="cat.category"
-              :subtitle="`Created on ${formatDate(cat.createdon)}`"
-            />
+            >
+              <template #subtitle>
+                Created on {{ formatDate(cat.createdon) }} &middot;
+                {{ cat.budget != null ? `Budget: ₹${cat.budget.toFixed(2)}/month` : 'No budget set' }}
+              </template>
+              <template #append>
+                <v-btn icon="mdi-pencil" variant="text" size="small" @click="openBudgetDialog(cat)" />
+              </template>
+            </v-list-item>
           </v-list>
           <p v-else class="text-center text-grey mt-6">No categories yet. Add one above.</p>
         </v-card>
       </v-col>
     </v-row>
+
+    <!-- Edit budget popup -->
+    <v-dialog v-model="budgetDialogOpen" max-width="360">
+      <v-card class="pa-4 rounded-xl">
+        <v-card-title>Set Budget &mdash; {{ budgetDialogCategory?.category }}</v-card-title>
+        <v-card-text>
+          <v-text-field
+            v-model="budgetInput"
+            label="Monthly Budget"
+            type="number"
+            variant="outlined"
+            hint="Leave blank to remove the budget"
+            persistent-hint
+            autofocus
+            @keyup.enter="onSaveBudget"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="budgetDialogOpen = false">Cancel</v-btn>
+          <v-btn color="primary" @click="onSaveBudget">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -48,10 +87,24 @@ import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { formatDate } from '~/composables/useFormatDate'
 
+interface Category {
+  catid: string
+  category: string
+  createdon: string
+  userid: string
+  budget: number | null
+}
+
 const router = useRouter()
-const categories = ref<Array<{ catid: string; category: string; createdon: string; userid: string }>>([])
+const categories = ref<Category[]>([])
 const newCategory = ref('')
+const newBudget = ref('')
 const errorMessage = ref('')
+
+const budgetDialogOpen = ref(false)
+const budgetDialogCategory = ref<Category | null>(null)
+const budgetInput = ref('')
+
 let userid = ''
 
 const loadCategories = async () => {
@@ -66,12 +119,36 @@ const onAddCategory = async () => {
   try {
     await $fetch('/categories', {
       method: 'POST',
-      body: { userid, category },
+      body: { userid, category, budget: newBudget.value || null },
     })
     newCategory.value = ''
+    newBudget.value = ''
     await loadCategories()
   } catch (err: any) {
     errorMessage.value = err?.data?.statusMessage || 'Failed to add category'
+  }
+}
+
+const openBudgetDialog = (cat: Category) => {
+  budgetDialogCategory.value = cat
+  budgetInput.value = cat.budget != null ? String(cat.budget) : ''
+  errorMessage.value = ''
+  budgetDialogOpen.value = true
+}
+
+const onSaveBudget = async () => {
+  if (!budgetDialogCategory.value) return
+  errorMessage.value = ''
+
+  try {
+    await $fetch('/categories', {
+      method: 'PUT',
+      body: { userid, catid: budgetDialogCategory.value.catid, budget: budgetInput.value || null },
+    })
+    budgetDialogOpen.value = false
+    await loadCategories()
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || 'Failed to update budget'
   }
 }
 

--- a/pages/expense.vue
+++ b/pages/expense.vue
@@ -92,6 +92,17 @@
               </div>
               <div class="expense-info">
                 <p class="name">{{ item.category }}</p>
+                <div v-if="item.budget" class="budget-bar-wrap">
+                  <div class="budget-bar">
+                    <div
+                      class="budget-bar-fill"
+                      :style="{ width: budgetPercent(item) + '%', background: budgetBarColor(item) }"
+                    />
+                  </div>
+                  <span class="budget-caption">
+                    {{ formatCurrency(item.monthSpent) }} / {{ formatCurrency(item.budget) }} this month
+                  </span>
+                </div>
               </div>
               <div class="expense-amount">{{ formatCurrency(item.amount) }}</div>
             </div>
@@ -221,6 +232,8 @@ interface ExpenseTotal {
   catid: string
   category: string
   amount: number
+  budget: number | null
+  monthSpent: number
 }
 
 interface DateGroup {
@@ -303,6 +316,19 @@ const categoryStyle = (name: string): CategoryStyle => {
 const modalCategoryStyle = computed(() =>
   categoryStyle(editingEntry.value ? selectedCategoryName.value : dialogCategory.value?.category || ''),
 )
+
+const budgetPercent = (item: ExpenseTotal) => {
+  if (!item.budget) return 0
+  return Math.min(100, (item.monthSpent / item.budget) * 100)
+}
+
+const budgetBarColor = (item: ExpenseTotal) => {
+  if (!item.budget) return 'var(--green-400)'
+  const ratio = item.monthSpent / item.budget
+  if (ratio >= 1) return '#b23a3a'
+  if (ratio >= 0.8) return 'var(--amber-200)'
+  return 'var(--green-400)'
+}
 
 const loadCategories = async () => {
   categories.value = await $fetch('/categories', { query: { userid } })
@@ -687,6 +713,31 @@ onMounted(async () => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.budget-bar-wrap {
+  margin-top: 6px;
+}
+
+.budget-bar {
+  height: 6px;
+  border-radius: 4px;
+  background: var(--border);
+  overflow: hidden;
+}
+
+.budget-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.2s ease;
+}
+
+.budget-caption {
+  display: block;
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .expense-amount {

--- a/server/routes/categories/index.put.ts
+++ b/server/routes/categories/index.put.ts
@@ -1,12 +1,12 @@
-import { createCategory } from '../../utils/spendnest'
+import { updateCategoryBudget } from '../../utils/spendnest'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const userid = String(body?.userid ?? '').trim()
-  const category = String(body?.category ?? '').trim()
+  const catid = String(body?.catid ?? '').trim()
 
-  if (!userid || !category) {
-    throw createError({ statusCode: 400, statusMessage: 'userid and category are required' })
+  if (!userid || !catid) {
+    throw createError({ statusCode: 400, statusMessage: 'userid and catid are required' })
   }
 
   let budget: number | null = null
@@ -18,10 +18,10 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    return await createCategory(userid, category, budget)
+    return await updateCategoryBudget(userid, catid, budget)
   } catch (err: any) {
-    if (err.message === 'CATEGORY_EXISTS') {
-      throw createError({ statusCode: 409, statusMessage: 'Category already exists' })
+    if (err.message === 'CATEGORY_NOT_FOUND') {
+      throw createError({ statusCode: 404, statusMessage: 'Category not found' })
     }
     throw err
   }

--- a/server/routes/expenses/index.get.ts
+++ b/server/routes/expenses/index.get.ts
@@ -1,5 +1,14 @@
 import { aggregateExpensesByCategory, getCategories, getExpenses } from '../../utils/spendnest'
 
+function currentMonthRange() {
+  const now = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const start = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-01`
+  const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+  const end = `${lastDay.getFullYear()}-${pad(lastDay.getMonth() + 1)}-${pad(lastDay.getDate())}`
+  return { start, end }
+}
+
 export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const userid = String(query.userid ?? '')
@@ -10,16 +19,23 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'userid is required' })
   }
 
-  const [categories, entries] = await Promise.all([
+  const { start: monthStart, end: monthEnd } = currentMonthRange()
+
+  const [categories, entries, monthEntries] = await Promise.all([
     getCategories(userid),
     getExpenses(userid, from || undefined, to || undefined),
+    getExpenses(userid, monthStart, monthEnd),
   ])
 
   const totalsByCategory = aggregateExpensesByCategory(entries)
+  const monthTotalsByCategory = aggregateExpensesByCategory(monthEntries)
+
   const totals = categories.map(c => ({
     catid: c.catid,
     category: c.category,
     amount: totalsByCategory[c.category] || 0,
+    budget: c.budget,
+    monthSpent: monthTotalsByCategory[c.category] || 0,
   }))
 
   return { entries, totals }

--- a/server/utils/spendnest.ts
+++ b/server/utils/spendnest.ts
@@ -14,6 +14,7 @@ export interface CategoryRow {
   category: string
   createdon: string
   userid: string
+  budget: number | null
 }
 
 export interface ExpenseEntry {
@@ -70,30 +71,48 @@ export async function resetPassword(email: string, newPassword: string): Promise
   }
 }
 
+const withBudgetNumber = (row: any): CategoryRow => ({
+  ...row,
+  budget: row.budget === null ? null : Number(row.budget),
+})
+
 export async function getCategories(userid: string): Promise<CategoryRow[]> {
   const { rows } = await getPool().query(
-    `select catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid
+    `select catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid, budget
      from categories where userid = $1 order by createdon desc`,
     [userid],
   )
-  return rows
+  return rows.map(withBudgetNumber)
 }
 
-export async function createCategory(userid: string, category: string): Promise<CategoryRow> {
+export async function createCategory(userid: string, category: string, budget: number | null = null): Promise<CategoryRow> {
   try {
     const { rows } = await getPool().query(
-      `insert into categories (category, userid)
-       values ($1, $2)
-       returning catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid`,
-      [category, userid],
+      `insert into categories (category, userid, budget)
+       values ($1, $2, $3)
+       returning catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid, budget`,
+      [category, userid, budget],
     )
-    return rows[0]
+    return withBudgetNumber(rows[0])
   } catch (err: any) {
     if (err.code === '23505') {
       throw new Error('CATEGORY_EXISTS')
     }
     throw err
   }
+}
+
+export async function updateCategoryBudget(userid: string, catid: string, budget: number | null): Promise<CategoryRow> {
+  const { rows } = await getPool().query(
+    `update categories set budget = $1
+     where catid = $2 and userid = $3
+     returning catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid, budget`,
+    [budget, catid, userid],
+  )
+  if (!rows[0]) {
+    throw new Error('CATEGORY_NOT_FOUND')
+  }
+  return withBudgetNumber(rows[0])
 }
 
 export async function getExpenses(userid: string, from?: string, to?: string): Promise<ExpenseEntry[]> {


### PR DESCRIPTION
Lets a category have an optional monthly budget, settable at creation or edited later from the category list. The expense "View Total" tab shows a progress bar per category comparing this calendar month's spend against its budget (color-coded green/amber/red), computed independently of whatever date-range filter is active on the page, since a monthly budget target shouldn't shift based on an ad-hoc viewing filter.