### PR TITLE
Normalize expenses to reference catid, add category edit/delete, and …

### DIFF
--- a/pages/category.vue
+++ b/pages/category.vue
@@ -26,7 +26,7 @@
               clearable
               @keyup.enter="onAddCategory"
             />
-            <v-btn color="primary" height="56" @click="onAddCategory">
+            <v-btn color="primary" height="56" :loading="addingCategory" :disabled="addingCategory" @click="onAddCategory">
               Add
             </v-btn>
           </div>
@@ -47,7 +47,8 @@
                 {{ cat.budget != null ? `Budget: ₹${cat.budget.toFixed(2)}/month` : 'No budget set' }}
               </template>
               <template #append>
-                <v-btn icon="mdi-pencil" variant="text" size="small" @click="openBudgetDialog(cat)" />
+                <v-btn icon="mdi-pencil" variant="text" size="small" @click="openEditDialog(cat)" />
+                <v-btn icon="mdi-delete" variant="text" size="small" color="error" @click="onDeleteCategory(cat)" />
               </template>
             </v-list-item>
           </v-list>
@@ -56,26 +57,59 @@
       </v-col>
     </v-row>
 
-    <!-- Edit budget popup -->
-    <v-dialog v-model="budgetDialogOpen" max-width="360">
+    <!-- Edit category popup -->
+    <v-dialog v-model="editDialogOpen" max-width="380">
       <v-card class="pa-4 rounded-xl">
-        <v-card-title>Set Budget &mdash; {{ budgetDialogCategory?.category }}</v-card-title>
+        <v-card-title>Edit Category</v-card-title>
         <v-card-text>
+          <v-alert type="warning" density="compact" variant="tonal" class="mb-4">
+            If you edit or delete a category, all data associated with that category will also be updated or deleted.
+            Please be careful before performing this operation.
+          </v-alert>
+
           <v-text-field
-            v-model="budgetInput"
+            v-model="editName"
+            label="Category Name"
+            variant="outlined"
+            class="mb-2"
+            clearable
+          />
+          <v-text-field
+            v-model="editBudget"
             label="Monthly Budget"
             type="number"
             variant="outlined"
             hint="Leave blank to remove the budget"
             persistent-hint
-            autofocus
-            @keyup.enter="onSaveBudget"
+            clearable
+            @keyup.enter="onSaveEdit"
           />
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="budgetDialogOpen = false">Cancel</v-btn>
-          <v-btn color="primary" @click="onSaveBudget">Save</v-btn>
+          <v-btn variant="text" :disabled="savingEdit" @click="editDialogOpen = false">Cancel</v-btn>
+          <v-btn color="primary" :loading="savingEdit" :disabled="savingEdit" @click="onSaveEdit">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Delete category popup -->
+    <v-dialog v-model="deleteDialogOpen" max-width="380">
+      <v-card class="pa-4 rounded-xl">
+        <v-card-title>Delete Category</v-card-title>
+        <v-card-text>
+          <v-alert type="warning" density="compact" variant="tonal" class="mb-4">
+            If you edit or delete a category, all data associated with that category will also be updated or deleted.
+            Please be careful before performing this operation.
+          </v-alert>
+          <p>
+            Delete <b>{{ deleteCategoryTarget?.category }}</b> and every expense recorded under it? This cannot be undone.
+          </p>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" :disabled="deletingCategory" @click="deleteDialogOpen = false">Cancel</v-btn>
+          <v-btn color="error" :loading="deletingCategory" :disabled="deletingCategory" @click="onConfirmDelete">Delete</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -101,9 +135,17 @@ const newCategory = ref('')
 const newBudget = ref('')
 const errorMessage = ref('')
 
-const budgetDialogOpen = ref(false)
-const budgetDialogCategory = ref<Category | null>(null)
-const budgetInput = ref('')
+const editDialogOpen = ref(false)
+const editCategory = ref<Category | null>(null)
+const editName = ref('')
+const editBudget = ref('')
+
+const deleteDialogOpen = ref(false)
+const deleteCategoryTarget = ref<Category | null>(null)
+
+const addingCategory = ref(false)
+const savingEdit = ref(false)
+const deletingCategory = ref(false)
 
 let userid = ''
 
@@ -116,6 +158,7 @@ const onAddCategory = async () => {
   const category = newCategory.value.trim()
   if (!category) return
 
+  addingCategory.value = true
   try {
     await $fetch('/categories', {
       method: 'POST',
@@ -126,29 +169,65 @@ const onAddCategory = async () => {
     await loadCategories()
   } catch (err: any) {
     errorMessage.value = err?.data?.statusMessage || 'Failed to add category'
+  } finally {
+    addingCategory.value = false
   }
 }
 
-const openBudgetDialog = (cat: Category) => {
-  budgetDialogCategory.value = cat
-  budgetInput.value = cat.budget != null ? String(cat.budget) : ''
+const openEditDialog = (cat: Category) => {
+  editCategory.value = cat
+  editName.value = cat.category
+  editBudget.value = cat.budget != null ? String(cat.budget) : ''
   errorMessage.value = ''
-  budgetDialogOpen.value = true
+  editDialogOpen.value = true
 }
 
-const onSaveBudget = async () => {
-  if (!budgetDialogCategory.value) return
-  errorMessage.value = ''
+const onSaveEdit = async () => {
+  if (!editCategory.value) return
 
+  errorMessage.value = ''
+  savingEdit.value = true
   try {
     await $fetch('/categories', {
       method: 'PUT',
-      body: { userid, catid: budgetDialogCategory.value.catid, budget: budgetInput.value || null },
+      body: {
+        userid,
+        catid: editCategory.value.catid,
+        category: editName.value.trim(),
+        budget: editBudget.value || null,
+      },
     })
-    budgetDialogOpen.value = false
+    editDialogOpen.value = false
     await loadCategories()
   } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || 'Failed to update budget'
+    errorMessage.value = err?.data?.statusMessage || 'Failed to update category'
+  } finally {
+    savingEdit.value = false
+  }
+}
+
+const onDeleteCategory = (cat: Category) => {
+  deleteCategoryTarget.value = cat
+  errorMessage.value = ''
+  deleteDialogOpen.value = true
+}
+
+const onConfirmDelete = async () => {
+  if (!deleteCategoryTarget.value) return
+
+  errorMessage.value = ''
+  deletingCategory.value = true
+  try {
+    await $fetch('/categories', {
+      method: 'DELETE',
+      query: { userid, catid: deleteCategoryTarget.value.catid },
+    })
+    deleteDialogOpen.value = false
+    await loadCategories()
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || 'Failed to delete category'
+  } finally {
+    deletingCategory.value = false
   }
 }
 

--- a/pages/expense.vue
+++ b/pages/expense.vue
@@ -142,12 +142,25 @@
                 </div>
                 <div class="expense-amount">{{ formatCurrency(item.amount) }}</div>
                 <div v-if="dateViewMode === 'edit'" class="row-actions">
-                  <button class="edit-icon" aria-label="Edit expense" @click="openEditDialog(item)">
-                    <i class="mdi mdi-pencil" />
-                  </button>
-                  <button class="delete-icon" aria-label="Delete expense" @click="onDeleteExpense(item)">
-                    <i class="mdi mdi-trash-can-outline" />
-                  </button>
+                  <v-btn
+                    icon="mdi-pencil"
+                    variant="text"
+                    size="small"
+                    class="edit-icon"
+                    :disabled="deletingExpenseId === item.expenseid"
+                    aria-label="Edit expense"
+                    @click="openEditDialog(item)"
+                  />
+                  <v-btn
+                    icon="mdi-trash-can-outline"
+                    variant="text"
+                    size="small"
+                    class="delete-icon"
+                    :loading="deletingExpenseId === item.expenseid"
+                    :disabled="deletingExpenseId === item.expenseid"
+                    aria-label="Delete expense"
+                    @click="onDeleteExpense(item)"
+                  />
                 </div>
               </div>
             </template>
@@ -174,8 +187,8 @@
           </span>
           <div class="modal-header-text">
             <p class="modal-title">{{ editingEntry ? 'Edit Expense' : 'Add Expense' }}</p>
-            <select v-if="editingEntry" v-model="selectedCategoryName" class="modal-select modal-select-inline">
-              <option v-for="cat in categories" :key="cat.catid" :value="cat.category">{{ cat.category }}</option>
+            <select v-if="editingEntry" v-model="selectedCatId" class="modal-select modal-select-inline">
+              <option v-for="cat in categories" :key="cat.catid" :value="cat.catid">{{ cat.category }}</option>
             </select>
             <p v-else class="modal-category">{{ dialogCategory?.category }}</p>
           </div>
@@ -200,8 +213,17 @@
         <textarea v-model="description" class="modal-textarea" rows="2" placeholder="Add a note..." />
 
         <div class="modal-actions">
-          <button class="modal-btn solid" @click="onSubmitExpense">Save Expense</button>
-          <button class="modal-btn ghost" @click="dialogOpen = false">Cancel</button>
+          <v-btn
+            class="modal-btn solid"
+            :loading="submittingExpense"
+            :disabled="submittingExpense"
+            @click="onSubmitExpense"
+          >
+            Save Expense
+          </v-btn>
+          <v-btn class="modal-btn ghost" variant="text" :disabled="submittingExpense" @click="dialogOpen = false">
+            Cancel
+          </v-btn>
         </div>
       </div>
     </v-dialog>
@@ -222,6 +244,7 @@ interface Category {
 
 interface ExpenseEntry {
   expenseid: string
+  catid: string
   category: string
   amount: number
   description: string
@@ -252,10 +275,12 @@ const errorMessage = ref('')
 const dialogOpen = ref(false)
 const dialogCategory = ref<Category | null>(null)
 const editingEntry = ref<ExpenseEntry | null>(null)
-const selectedCategoryName = ref('')
+const selectedCatId = ref('')
 const amount = ref('')
 const expenseDate = ref('')
 const description = ref('')
+const submittingExpense = ref(false)
+const deletingExpenseId = ref<string | null>(null)
 
 const dateFrom = ref('')
 const dateTo = ref('')
@@ -313,9 +338,14 @@ const categoryStyle = (name: string): CategoryStyle => {
   return FALLBACK_PALETTE[idx]
 }
 
-const modalCategoryStyle = computed(() =>
-  categoryStyle(editingEntry.value ? selectedCategoryName.value : dialogCategory.value?.category || ''),
-)
+const activeCategory = computed<Category | null>(() => {
+  if (editingEntry.value) {
+    return categories.value.find(c => c.catid === selectedCatId.value) || null
+  }
+  return dialogCategory.value
+})
+
+const modalCategoryStyle = computed(() => categoryStyle(activeCategory.value?.category || ''))
 
 const budgetPercent = (item: ExpenseTotal) => {
   if (!item.budget) return 0
@@ -362,7 +392,7 @@ watch([dateFrom, dateTo], () => {
 const openAddDialog = (cat: Category) => {
   editingEntry.value = null
   dialogCategory.value = cat
-  selectedCategoryName.value = cat.category
+  selectedCatId.value = cat.catid
   amount.value = ''
   expenseDate.value = todayStr()
   description.value = ''
@@ -373,7 +403,7 @@ const openAddDialog = (cat: Category) => {
 const openEditDialog = (entry: ExpenseEntry) => {
   editingEntry.value = entry
   dialogCategory.value = null
-  selectedCategoryName.value = entry.category
+  selectedCatId.value = entry.catid
   amount.value = String(entry.amount)
   expenseDate.value = entry.dateofexpense
   description.value = entry.description
@@ -384,9 +414,9 @@ const openEditDialog = (entry: ExpenseEntry) => {
 const onSubmitExpense = async () => {
   errorMessage.value = ''
   const value = Number(amount.value)
-  const category = selectedCategoryName.value
+  const catid = activeCategory.value?.catid
 
-  if (!category || !Number.isFinite(value) || value <= 0) {
+  if (!catid || !Number.isFinite(value) || value <= 0) {
     errorMessage.value = 'Enter a valid amount.'
     return
   }
@@ -395,6 +425,7 @@ const onSubmitExpense = async () => {
     return
   }
 
+  submittingExpense.value = true
   try {
     if (editingEntry.value) {
       await $fetch('/expenses', {
@@ -402,7 +433,7 @@ const onSubmitExpense = async () => {
         body: {
           userid,
           expenseid: editingEntry.value.expenseid,
-          category,
+          catid,
           amount: value,
           dateofexpense: expenseDate.value,
           description: description.value,
@@ -411,13 +442,15 @@ const onSubmitExpense = async () => {
     } else {
       await $fetch('/expenses', {
         method: 'POST',
-        body: { userid, category, amount: value, dateofexpense: expenseDate.value, description: description.value },
+        body: { userid, catid, amount: value, dateofexpense: expenseDate.value, description: description.value },
       })
     }
     dialogOpen.value = false
     await loadExpenses()
   } catch (err: any) {
     errorMessage.value = err?.data?.statusMessage || 'Failed to save expense'
+  } finally {
+    submittingExpense.value = false
   }
 }
 
@@ -425,6 +458,7 @@ const onDeleteExpense = async (entry: ExpenseEntry) => {
   if (!confirm(`Delete this ${entry.category} expense of ${entry.amount}?`)) return
 
   errorMessage.value = ''
+  deletingExpenseId.value = entry.expenseid
   try {
     await $fetch('/expenses', {
       method: 'DELETE',
@@ -433,6 +467,8 @@ const onDeleteExpense = async (entry: ExpenseEntry) => {
     await loadExpenses()
   } catch (err: any) {
     errorMessage.value = err?.data?.statusMessage || 'Failed to delete expense'
+  } finally {
+    deletingExpenseId.value = null
   }
 }
 

--- a/server/routes/categories/index.delete.ts
+++ b/server/routes/categories/index.delete.ts
@@ -1,0 +1,21 @@
+import { deleteCategory } from '../../utils/spendnest'
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const userid = String(query.userid ?? '')
+  const catid = String(query.catid ?? '')
+
+  if (!userid || !catid) {
+    throw createError({ statusCode: 400, statusMessage: 'userid and catid are required' })
+  }
+
+  try {
+    await deleteCategory(userid, catid)
+    return { success: true }
+  } catch (err: any) {
+    if (err.message === 'CATEGORY_NOT_FOUND') {
+      throw createError({ statusCode: 404, statusMessage: 'Category not found' })
+    }
+    throw err
+  }
+})

--- a/server/routes/categories/index.put.ts
+++ b/server/routes/categories/index.put.ts
@@ -1,4 +1,4 @@
-import { updateCategoryBudget } from '../../utils/spendnest'
+import { updateCategory } from '../../utils/spendnest'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
@@ -9,19 +9,39 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'userid and catid are required' })
   }
 
-  let budget: number | null = null
-  if (body?.budget !== null && body?.budget !== undefined && body?.budget !== '') {
-    budget = Number(body.budget)
-    if (!Number.isFinite(budget) || budget < 0) {
-      throw createError({ statusCode: 400, statusMessage: 'budget must be a non-negative number' })
+  const changes: { category?: string; budget?: number | null } = {}
+
+  if (body?.category !== undefined) {
+    const category = String(body.category).trim()
+    if (!category) {
+      throw createError({ statusCode: 400, statusMessage: 'category cannot be empty' })
+    }
+    changes.category = category
+  }
+
+  if (body?.budget !== undefined) {
+    if (body.budget === null || body.budget === '') {
+      changes.budget = null
+    } else {
+      const budget = Number(body.budget)
+      if (!Number.isFinite(budget) || budget < 0) {
+        throw createError({ statusCode: 400, statusMessage: 'budget must be a non-negative number' })
+      }
+      changes.budget = budget
     }
   }
 
   try {
-    return await updateCategoryBudget(userid, catid, budget)
+    return await updateCategory(userid, catid, changes)
   } catch (err: any) {
     if (err.message === 'CATEGORY_NOT_FOUND') {
       throw createError({ statusCode: 404, statusMessage: 'Category not found' })
+    }
+    if (err.message === 'CATEGORY_EXISTS') {
+      throw createError({ statusCode: 409, statusMessage: 'Category already exists' })
+    }
+    if (err.message === 'NOTHING_TO_UPDATE') {
+      throw createError({ statusCode: 400, statusMessage: 'Nothing to update' })
     }
     throw err
   }

--- a/server/routes/expenses/index.post.ts
+++ b/server/routes/expenses/index.post.ts
@@ -5,13 +5,13 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const userid = String(body?.userid ?? '').trim()
-  const category = String(body?.category ?? '').trim()
+  const catid = String(body?.catid ?? '').trim()
   const amount = Number(body?.amount)
   const dateofexpense = String(body?.dateofexpense ?? '').trim()
   const description = String(body?.description ?? '').trim()
 
-  if (!userid || !category) {
-    throw createError({ statusCode: 400, statusMessage: 'userid and category are required' })
+  if (!userid || !catid) {
+    throw createError({ statusCode: 400, statusMessage: 'userid and catid are required' })
   }
   if (!Number.isFinite(amount) || amount <= 0) {
     throw createError({ statusCode: 400, statusMessage: 'amount must be a positive number' })
@@ -20,5 +20,5 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'dateofexpense must be a valid YYYY-MM-DD date' })
   }
 
-  return await addExpense(userid, category, amount, dateofexpense, description)
+  return await addExpense(userid, catid, amount, dateofexpense, description)
 })

--- a/server/routes/expenses/index.put.ts
+++ b/server/routes/expenses/index.put.ts
@@ -6,13 +6,13 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const userid = String(body?.userid ?? '').trim()
   const expenseid = String(body?.expenseid ?? '').trim()
-  const category = String(body?.category ?? '').trim()
+  const catid = String(body?.catid ?? '').trim()
   const amount = Number(body?.amount)
   const dateofexpense = String(body?.dateofexpense ?? '').trim()
   const description = String(body?.description ?? '').trim()
 
-  if (!userid || !expenseid || !category) {
-    throw createError({ statusCode: 400, statusMessage: 'userid, expenseid and category are required' })
+  if (!userid || !expenseid || !catid) {
+    throw createError({ statusCode: 400, statusMessage: 'userid, expenseid and catid are required' })
   }
   if (!Number.isFinite(amount) || amount <= 0) {
     throw createError({ statusCode: 400, statusMessage: 'amount must be a positive number' })
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    return await updateExpense(userid, expenseid, category, amount, dateofexpense, description)
+    return await updateExpense(userid, expenseid, catid, amount, dateofexpense, description)
   } catch (err: any) {
     if (err.message === 'EXPENSE_NOT_FOUND') {
       throw createError({ statusCode: 404, statusMessage: 'Expense not found' })

--- a/server/utils/spendnest.ts
+++ b/server/utils/spendnest.ts
@@ -19,6 +19,7 @@ export interface CategoryRow {
 
 export interface ExpenseEntry {
   expenseid: string
+  catid: string
   category: string
   amount: number
   description: string
@@ -102,34 +103,78 @@ export async function createCategory(userid: string, category: string, budget: n
   }
 }
 
-export async function updateCategoryBudget(userid: string, catid: string, budget: number | null): Promise<CategoryRow> {
-  const { rows } = await getPool().query(
-    `update categories set budget = $1
-     where catid = $2 and userid = $3
-     returning catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid, budget`,
-    [budget, catid, userid],
-  )
-  if (!rows[0]) {
+// Since expenses only ever reference catid (not a duplicated name), renaming a
+// category needs no cascade at all -- every linked expense resolves the new
+// name automatically through the join in getExpenses.
+export async function updateCategory(
+  userid: string,
+  catid: string,
+  changes: { category?: string; budget?: number | null },
+): Promise<CategoryRow> {
+  const sets: string[] = []
+  const params: any[] = []
+
+  if (changes.category !== undefined) {
+    params.push(changes.category)
+    sets.push(`category = $${params.length}`)
+  }
+  if ('budget' in changes) {
+    params.push(changes.budget)
+    sets.push(`budget = $${params.length}`)
+  }
+  if (!sets.length) {
+    throw new Error('NOTHING_TO_UPDATE')
+  }
+
+  params.push(catid, userid)
+
+  try {
+    const { rows } = await getPool().query(
+      `update categories set ${sets.join(', ')}
+       where catid = $${params.length - 1} and userid = $${params.length}
+       returning catid, category, to_char(createdon, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as createdon, userid, budget`,
+      params,
+    )
+    if (!rows[0]) {
+      throw new Error('CATEGORY_NOT_FOUND')
+    }
+    return withBudgetNumber(rows[0])
+  } catch (err: any) {
+    if (err.code === '23505') {
+      throw new Error('CATEGORY_EXISTS')
+    }
+    throw err
+  }
+}
+
+// Relies on expenses.catid's ON DELETE CASCADE foreign key -- deleting the
+// category row automatically removes every expense that referenced it.
+export async function deleteCategory(userid: string, catid: string): Promise<void> {
+  const { rowCount } = await getPool().query('delete from categories where catid = $1 and userid = $2', [catid, userid])
+  if (rowCount === 0) {
     throw new Error('CATEGORY_NOT_FOUND')
   }
-  return withBudgetNumber(rows[0])
 }
 
 export async function getExpenses(userid: string, from?: string, to?: string): Promise<ExpenseEntry[]> {
-  const conditions = ['userid = $1']
+  const conditions = ['e.userid = $1']
   const params: any[] = [userid]
   if (from) {
     params.push(from)
-    conditions.push(`dateofexpense >= $${params.length}`)
+    conditions.push(`e.dateofexpense >= $${params.length}`)
   }
   if (to) {
     params.push(to)
-    conditions.push(`dateofexpense <= $${params.length}`)
+    conditions.push(`e.dateofexpense <= $${params.length}`)
   }
 
   const { rows } = await getPool().query(
-    `select expenseid, category, amount, coalesce(description, '') as description, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense
-     from expenses where ${conditions.join(' and ')} order by dateofexpense desc`,
+    `select e.expenseid, e.catid, c.category, e.amount, coalesce(e.description, '') as description,
+            to_char(e.dateofexpense, 'YYYY-MM-DD') as dateofexpense
+     from expenses e
+     join categories c on c.catid = e.catid
+     where ${conditions.join(' and ')}
+     order by e.dateofexpense desc`,
     params,
   )
   return rows.map(r => ({ ...r, amount: Number(r.amount) }))
@@ -137,16 +182,22 @@ export async function getExpenses(userid: string, from?: string, to?: string): P
 
 export async function addExpense(
   userid: string,
-  category: string,
+  catid: string,
   amount: number,
   dateofexpense: string,
   description: string,
 ): Promise<ExpenseEntry> {
   const { rows } = await getPool().query(
-    `insert into expenses (category, amount, userid, dateofexpense, description)
-     values ($1, $2, $3, $4, $5)
-     returning expenseid, category, amount, coalesce(description, '') as description, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
-    [category, amount, userid, dateofexpense, description],
+    `with inserted as (
+       insert into expenses (catid, amount, userid, dateofexpense, description)
+       values ($1, $2, $3, $4, $5)
+       returning expenseid, catid, amount, description, dateofexpense
+     )
+     select i.expenseid, i.catid, c.category, i.amount, coalesce(i.description, '') as description,
+            to_char(i.dateofexpense, 'YYYY-MM-DD') as dateofexpense
+     from inserted i
+     join categories c on c.catid = i.catid`,
+    [catid, amount, userid, dateofexpense, description],
   )
   return { ...rows[0], amount: Number(rows[0].amount) }
 }
@@ -154,16 +205,22 @@ export async function addExpense(
 export async function updateExpense(
   userid: string,
   expenseid: string,
-  category: string,
+  catid: string,
   amount: number,
   dateofexpense: string,
   description: string,
 ): Promise<ExpenseEntry> {
   const { rows } = await getPool().query(
-    `update expenses set category = $1, amount = $2, dateofexpense = $3, description = $4
-     where expenseid = $5 and userid = $6
-     returning expenseid, category, amount, coalesce(description, '') as description, to_char(dateofexpense, 'YYYY-MM-DD') as dateofexpense`,
-    [category, amount, dateofexpense, description, expenseid, userid],
+    `with updated as (
+       update expenses set catid = $1, amount = $2, dateofexpense = $3, description = $4
+       where expenseid = $5 and userid = $6
+       returning expenseid, catid, amount, description, dateofexpense
+     )
+     select u.expenseid, u.catid, c.category, u.amount, coalesce(u.description, '') as description,
+            to_char(u.dateofexpense, 'YYYY-MM-DD') as dateofexpense
+     from updated u
+     join categories c on c.catid = u.catid`,
+    [catid, amount, dateofexpense, description, expenseid, userid],
   )
   if (!rows[0]) {
     throw new Error('EXPENSE_NOT_FOUND')


### PR DESCRIPTION
…loading states

Replaces the denormalized expenses.category text column with a proper catid foreign key (ON DELETE CASCADE), so deleting a category automatically removes its expenses at the database level and renaming a category needs no cascade at all -- every expense resolves the current name through a join.

Adds category rename/delete from the Categories page, each behind a styled warning dialog (not a native confirm()) since both operations affect all of that category's expense data. Also adds Vuetify loading states to the Add/Save/Delete category buttons and the expense Save/Delete actions, so in-flight requests give visible feedback instead of appearing unresponsive.